### PR TITLE
修复插件在vscode 1.74.1 版本无法工作的问题

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.executeCommand('workbench.view.scm')
         if (uri) {
           let selectedRepository = git.repositories.find((repository) => {
-            return repository.rootUri.path === uri._rootUri.path
+            return repository.rootUri.path === uri.rootUri.path
           })
           if (selectedRepository) {
             prefixCommit(selectedRepository, selected.emoji)


### PR DESCRIPTION
修复插件在vscode 1.74.1 版本无法工作的问题 #25 